### PR TITLE
test: add failing reproducers for reconcile false-positive and ps/man…

### DIFF
--- a/libsloptest/src/lib.rs
+++ b/libsloptest/src/lib.rs
@@ -181,7 +181,7 @@ impl TestEnv {
     }
 
     pub fn spawn_slopd(&self) -> Child {
-        self.spawn_slopd_inner(None, &[])
+        self.spawn_slopd_inner(None, &[], &[])
     }
 
     /// Like `spawn_slopd` but sets `SLOPD_TEST_RUN_YIELD_MS` to the given value.
@@ -192,15 +192,20 @@ impl TestEnv {
     /// deterministic regression tests for the race described in:
     ///   fix: guard Run handler from resetting pane state that a concurrent hook already advanced
     pub fn spawn_slopd_with_run_yield(&self, delay_ms: u64) -> Child {
-        self.spawn_slopd_inner(Some(delay_ms), &[])
+        self.spawn_slopd_inner(Some(delay_ms), &[], &[])
     }
 
     /// Like `spawn_slopd` but passes extra CLI arguments to the slopd binary.
     pub fn spawn_slopd_with_args(&self, extra_args: &[&str]) -> Child {
-        self.spawn_slopd_inner(None, extra_args)
+        self.spawn_slopd_inner(None, extra_args, &[])
     }
 
-    fn spawn_slopd_inner(&self, run_yield_ms: Option<u64>, extra_args: &[&str]) -> Child {
+    /// Like `spawn_slopd` but injects extra environment variables.
+    pub fn spawn_slopd_with_envs(&self, envs: &[(&str, &str)]) -> Child {
+        self.spawn_slopd_inner(None, &[], envs)
+    }
+
+    fn spawn_slopd_inner(&self, run_yield_ms: Option<u64>, extra_args: &[&str], extra_envs: &[(&str, &str)]) -> Child {
         let mut cmd = Command::new(cargo_bin("slopd"));
         cmd.args(extra_args)
             .env("XDG_RUNTIME_DIR", self.runtime_dir.path())
@@ -213,6 +218,9 @@ impl TestEnv {
             .stderr(Stdio::null());
         if let Some(ms) = run_yield_ms {
             cmd.env("SLOPD_TEST_RUN_YIELD_MS", ms.to_string());
+        }
+        for (k, v) in extra_envs {
+            cmd.env(k, v);
         }
         let child = cmd.spawn().expect("failed to spawn slopd");
         // Wait for slopd to be ready by polling until a connection to its socket succeeds.

--- a/slopd/src/main.rs
+++ b/slopd/src/main.rs
@@ -817,6 +817,15 @@ async fn reconcile_panes(
         _ => return,
     };
 
+    // Test hook: simulate the production failure mode where `tmux list-panes`
+    // transiently returned without our managed panes.  Used by the reconcile
+    // false-positive regression test.
+    let live_ids = if std::env::var("SLOPD_TEST_RECONCILE_FORCE_EMPTY").is_ok() {
+        std::collections::HashSet::new()
+    } else {
+        live_ids
+    };
+
     let dead: Vec<String> = managed_panes.snapshot()
         .into_iter()
         .filter(|id| !live_ids.contains(id))

--- a/slopd/src/main.rs
+++ b/slopd/src/main.rs
@@ -826,12 +826,26 @@ async fn reconcile_panes(
         live_ids
     };
 
-    let dead: Vec<String> = managed_panes.snapshot()
+    let candidates: Vec<String> = managed_panes.snapshot()
         .into_iter()
         .filter(|id| !live_ids.contains(id))
         .collect();
 
-    for pane_id in dead {
+    for pane_id in candidates {
+        // The session-scoped list-panes call above can transiently fail to
+        // include a still-alive pane: the slopd session may be briefly missing
+        // (recreated between ticks), tmux may return "can't find session:"
+        // during a concurrent operation, or the result may be otherwise
+        // incomplete.  Once we wrongly call `managed_panes.remove(...)`, the
+        // pane is permanently disowned for the rest of this slopd's lifetime
+        // — Send/Interrupt/Tag all reject it, and hooks from it are dropped.
+        // Verify per-pane via show-options before declaring death.  Pane IDs
+        // are global to the tmux server, so this works regardless of which
+        // session the pane currently lives in.
+        if pane_is_still_alive(config, &pane_id).await {
+            continue;
+        }
+
         info!("pane {} no longer exists, emitting PaneDestroyed", pane_id);
         reparent_children_of(config, managed_panes, &pane_id).await;
         if let Some(state) = panes.remove(&pane_id) {
@@ -847,6 +861,35 @@ async fn reconcile_panes(
             }),
             cursor: None,
         });
+    }
+}
+
+/// Confirm that `pane_id` is still alive in tmux and still flagged as
+/// slopd-managed.  Returns `true` if show-options succeeds and reports
+/// `@slopd_managed=true`.  Returns `false` when tmux confirms the pane is
+/// gone (stderr signalling "no such pane:" / "can't find pane:") or when
+/// `@slopd_managed` has been cleared.  On ambiguous errors (e.g. tmux
+/// unavailable, unknown stderr) we return `true` to err on the side of
+/// keeping the pane managed — the next reconcile tick will retry, which is
+/// far cheaper than the alternative of permanently disowning a live pane.
+async fn pane_is_still_alive(config: &libslop::SlopdConfig, pane_id: &str) -> bool {
+    let out = tmux(config)
+        .args(["show-options", "-t", pane_id, "-p"])
+        .output()
+        .await;
+    match out {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            parse_pane_options(&stdout).slopd_managed
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // tmux phrasing varies by version: "no such pane:", "can't find pane:".
+            // Anything else is treated as a transient/ambiguous error and the
+            // pane is kept (caller will retry next tick).
+            !(stderr.contains("no such pane:") || stderr.contains("can't find pane:"))
+        }
+        Err(_) => true,
     }
 }
 
@@ -1351,19 +1394,20 @@ async fn reparent_children_of(
     }
 }
 
-async fn list_panes(config: &libslop::SlopdConfig, session_lock: &SessionLock) -> Result<Vec<libslop::PaneInfo>, String> {
-    let list_out = tmux_session_output(config, session_lock, |c| {
-        let mut cmd = tmux(c);
-        cmd.args(["list-panes", "-s", "-t", "slopd", "-F", "#{pane_id} #{window_activity} #{pane_current_path}"]);
-        cmd
-    })
-        .await
-        .map_err(|e| e.to_string())?;
-    if !list_out.status.success() {
-        return Err(String::from_utf8_lossy(&list_out.stderr).trim().to_string());
-    }
+async fn list_panes(config: &libslop::SlopdConfig, managed_panes: &ManagedPanes) -> Result<Vec<libslop::PaneInfo>, String> {
+    // Iterate slopd's authoritative in-memory managed_panes set, not
+    // `tmux list-panes`.  The two are not always equivalent:
+    //   - A pane can have @slopd_managed=true set in tmux yet not be in
+    //     managed_panes (stale option, manual `tmux new-window`, or a pane
+    //     that was reconciled away while still alive in tmux).  Showing such
+    //     a pane in `ps` confuses callers because Send/Interrupt/Tag all
+    //     reject it.
+    //   - managed_panes is what Send/Interrupt/Tag/Kill check, so iterating
+    //     it makes `ps` consistent with the operations a caller can perform.
+    // Per-pane metadata (activity, cwd, slopd options) still comes from tmux;
+    // panes that have died in tmux but are still in managed_panes are skipped
+    // here — the next reconcile tick will clean them up.
 
-    // First pass: collect all managed panes with their parsed options.
     struct RawPane {
         pane_id: String,
         last_active: u64,
@@ -1371,30 +1415,33 @@ async fn list_panes(config: &libslop::SlopdConfig, session_lock: &SessionLock) -
         opts: ParsedPaneOptions,
     }
     let mut raw_panes = Vec::new();
-    for line in String::from_utf8_lossy(&list_out.stdout).lines() {
-        let mut parts = line.splitn(3, ' ');
-        let pane_id = match parts.next() {
-            Some(p) if !p.is_empty() => p.to_string(),
+    for pane_id in managed_panes.snapshot() {
+        let dm_out = tmux(config)
+            .args(["display-message", "-p", "-t", &pane_id, "-F",
+                   "#{window_activity} #{pane_current_path}"])
+            .output()
+            .await;
+        let (last_active, working_dir) = match dm_out {
+            Ok(out) if out.status.success() => {
+                let line = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let mut parts = line.splitn(2, ' ');
+                let activity: u64 = parts.next().unwrap_or("0").trim().parse().unwrap_or(0);
+                let cwd = parts.next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+                (activity, cwd)
+            }
             _ => continue,
         };
-        let last_active: u64 = parts.next().unwrap_or("0").trim().parse().unwrap_or(0);
-        let working_dir = parts.next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
 
         let opts_out = tmux(config)
             .args(["show-options", "-t", &pane_id, "-p"])
             .output()
             .await;
-        match opts_out {
-            Ok(out) if out.status.success() => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let opts = parse_pane_options(&stdout);
-                if !opts.slopd_managed {
-                    continue;
-                }
-                raw_panes.push(RawPane { pane_id, last_active, working_dir, opts });
-            }
+        let opts = match opts_out {
+            Ok(out) if out.status.success() => parse_pane_options(&String::from_utf8_lossy(&out.stdout)),
             _ => continue,
         };
+
+        raw_panes.push(RawPane { pane_id, last_active, working_dir, opts });
     }
 
     // Build set of live managed pane IDs.
@@ -1962,7 +2009,7 @@ async fn handle_request(
         }
 
         libslop::RequestBody::Ps => {
-            match list_panes(config, session_lock).await {
+            match list_panes(config, managed_panes).await {
                 Ok(panes) => libslop::ResponseBody::Ps { panes },
                 Err(e) => libslop::ResponseBody::Error { message: e },
             }

--- a/slopd/tests/integration.rs
+++ b/slopd/tests/integration.rs
@@ -5856,3 +5856,135 @@ fn run_cli_env_overrides_config_env() {
     kill_slopd(slopd);
     assert_eq!(value, "from-cli", "CLI --env should override [run.env] in config");
 }
+
+/// Reproducer for the bug observed in production: when `tmux list-panes -s -t slopd`
+/// inside `reconcile_panes` transiently returns no panes (success+empty stdout, or
+/// "can't find session:" stderr — happens when the tmux session is briefly missing
+/// or when a tmux command interleave returns nothing), reconcile concluded that
+/// every managed pane was destroyed and removed it from the in-memory
+/// `managed_panes` set.  Once disowned, every subsequent `Send`/`Interrupt`/`Tag`
+/// returned "pane is not managed by slopd" — even though the pane was alive and
+/// continued running Claude.
+///
+/// Slopd journal at the time the production bug bit (Apr 26 20:46:25):
+///   "pane %1 no longer exists, emitting PaneDestroyed"
+///   followed by repeated "ignoring hook from unmanaged pane %1"
+///   followed by every dm-relay delivery failing with "is not managed by slopd"
+///
+/// The fix is per-pane verification: before declaring a managed pane destroyed,
+/// query its options directly (`show-options -t %X -p`).  If the pane is alive
+/// and still has `@slopd_managed=true` set, keep it.
+///
+/// This test injects the failure mode via `SLOPD_TEST_RECONCILE_FORCE_EMPTY=1`,
+/// which forces every reconcile tick to behave as if tmux returned an empty pane
+/// list.  Without the fix, reconcile removes the pane within one tick.  With the
+/// fix, per-pane verification preserves it.
+#[test]
+fn reconcile_does_not_disown_alive_pane_when_list_panes_returns_empty() {
+    build_bin("slopd");
+    build_bin("slopctl");
+    build_bin("mock_claude");
+
+    let mock_claude_path = cargo_bin("mock_claude").to_str().unwrap().to_string();
+    let Some(env) = TestEnv::new(Some(&[&mock_claude_path])) else {
+        eprintln!("skipping: tmux not found");
+        return;
+    };
+
+    let slopd = env.spawn_slopd_with_envs(&[("SLOPD_TEST_RECONCILE_FORCE_EMPTY", "1")]);
+
+    let run_output = env.slopctl(&["run"]);
+    assert!(run_output.status.success(), "slopctl run failed: {:?}", run_output);
+    let pane_id = String::from_utf8_lossy(&run_output.stdout).trim().to_string();
+
+    // Reconcile interval is 2 s.  Wait long enough that several ticks have fired
+    // and any false-positive removal would have happened.
+    std::thread::sleep(Duration::from_secs(5));
+
+    // The pane is still alive, and managed_panes should still contain it.
+    // `slopctl tag` only checks managed_panes, so it is a clean probe of whether
+    // the pane was wrongly disowned.  Before the fix this returns
+    // "pane %X is not managed by slopd"; after the fix it succeeds.
+    let tag_out = env.slopctl(&["tag", &pane_id, "verify"]);
+    let stderr = String::from_utf8_lossy(&tag_out.stderr);
+    assert!(
+        tag_out.status.success(),
+        "slopctl tag should succeed because pane is still alive, but got: status={:?} stderr={}",
+        tag_out.status,
+        stderr,
+    );
+
+    kill_slopd(slopd);
+}
+
+/// `slopctl ps` must reflect slopd's in-memory `managed_panes` set rather than
+/// arbitrary tmux pane options.  A pane that has `@slopd_managed=true` set on
+/// it but that is not in `managed_panes` (e.g. the option is stale, or a pane
+/// was created outside `slopctl run`) must NOT appear in `ps` output, because
+/// `Send`/`Interrupt`/`Tag` would all reject it as "pane is not managed".
+///
+/// Without this guarantee, dm-relay (and other clients) discover a pane via
+/// `slopctl ps`, then fail to operate on it because slopd's authoritative set
+/// disagrees — exactly the inconsistency that surfaced in the production
+/// disowning bug, where `slopctl ps` kept showing %1 long after slopd's
+/// `Send`/`Interrupt` started rejecting it.
+#[test]
+fn ps_reflects_managed_panes_not_tmux_options() {
+    build_bin("slopd");
+    build_bin("slopctl");
+
+    let Some(env) = TestEnv::new(Some(&["sleep", "60"])) else {
+        eprintln!("skipping: tmux not found");
+        return;
+    };
+
+    let slopd = env.spawn_slopd();
+
+    // Spawn a pane the normal way — this one IS in managed_panes.
+    let run_output = env.slopctl(&["run"]);
+    assert!(run_output.status.success(), "slopctl run failed: {:?}", run_output);
+    let managed_pane_id = String::from_utf8_lossy(&run_output.stdout).trim().to_string();
+
+    // Create an "impostor" pane: a fresh window in slopd's tmux session, with
+    // `@slopd_managed=true` set on it manually.  This pane was never inserted
+    // into managed_panes — it represents a stale option, a manual intervention,
+    // or a pane that was reconciled away while still alive in tmux.
+    let new_window_out = env.tmux.tmux()
+        .args(["new-window", "-d", "-t", "slopd", "-P", "-F", "#{pane_id}"])
+        .output()
+        .expect("tmux new-window failed");
+    assert!(new_window_out.status.success(),
+        "tmux new-window failed: stderr={}",
+        String::from_utf8_lossy(&new_window_out.stderr));
+    let impostor_pane_id = String::from_utf8_lossy(&new_window_out.stdout).trim().to_string();
+    assert!(impostor_pane_id.starts_with('%'),
+        "expected pane id like %42, got {:?}", impostor_pane_id);
+
+    let set_status = env.tmux.tmux()
+        .args(["set-option", "-t", &impostor_pane_id, "-p", "@slopd_managed", "true"])
+        .status()
+        .expect("tmux set-option failed");
+    assert!(set_status.success());
+
+    let ps_output = env.slopctl(&["ps", "--json"]);
+    assert!(ps_output.status.success(),
+        "slopctl ps failed: {:?}", String::from_utf8_lossy(&ps_output.stderr));
+    let panes: Vec<serde_json::Value> = serde_json::from_slice(&ps_output.stdout)
+        .expect("ps --json output should be JSON");
+    let pane_ids: Vec<&str> = panes.iter()
+        .map(|p| p["pane_id"].as_str().unwrap())
+        .collect();
+
+    assert!(
+        pane_ids.iter().any(|id| *id == managed_pane_id),
+        "managed pane {} should be in ps output: {:?}",
+        managed_pane_id, pane_ids,
+    );
+    assert!(
+        !pane_ids.iter().any(|id| *id == impostor_pane_id),
+        "impostor pane {} (not in managed_panes) must NOT be in ps output: {:?}",
+        impostor_pane_id, pane_ids,
+    );
+
+    kill_slopd(slopd);
+}


### PR DESCRIPTION
…aged_panes inconsistency

Captures two related production bugs observed in slopd-git r169.f13a7d3:

1. reconcile_panes false-positive: when `tmux list-panes -s -t slopd` inside
   the 2-second reconcile loop transiently returns empty (success+empty stdout
   or "can't find session:" stderr — happens when the slopd session is briefly
   missing or a tmux command interleave returns nothing), reconcile concludes
   that every managed pane is destroyed and removes it from the in-memory
   `managed_panes` set.  Once disowned, every subsequent Send/Interrupt/Tag
   returns "pane is not managed by slopd" — even though the pane is alive
   and continues running Claude.  Hooks from the pane are also dropped with
   "ignoring hook from unmanaged pane".

2. ps/managed_panes inconsistency: list_panes reads the pane universe from
   `tmux list-panes` and filters by @slopd_managed=true, while
   Send/Interrupt/Tag/Kill check the in-memory managed_panes set.  When the
   two diverge (e.g. after bug 1 disowns a pane that is still alive in tmux),
   `slopctl ps` keeps showing the pane while operations on it are rejected —
   the inconsistency dm-relay walked into when delivering "Status?" messages.

To make bug 1 deterministic, this commit adds a test-only env var
SLOPD_TEST_RECONCILE_FORCE_EMPTY that forces every reconcile tick to behave
as if tmux returned an empty pane list.  Same pattern as the existing
SLOPD_TEST_RUN_YIELD_MS hook.

Both tests fail before the fix.